### PR TITLE
✨ Add dependency on ffmpeg in SafeLock cask

### DIFF
--- a/Casks/safelock.rb
+++ b/Casks/safelock.rb
@@ -9,6 +9,8 @@ cask "safelock" do
 
   app "SafeLock.app"
 
+  depends_on formula: "ffmpeg"
+
   zap trash: [
     "~/Library/Application Support/SafeLock",
     "~/Library/Preferences/com.Zarox28.SafeLock.plist",


### PR DESCRIPTION
## Description
This pull request adds a dependency on ffmpeg in the SafeLock cask. This change ensures that SafeLock is able to utilize the functionalities provided by ffmpeg.