### PR TITLE
✨ feat: add ADBenQ formula for BenQ monitor control

### DIFF
--- a/Formula/adbenq.rb
+++ b/Formula/adbenq.rb
@@ -1,0 +1,16 @@
+class Adbenq < Formula
+  desc "Control your BenQ TV like a boss 🖥️✨"
+  homepage "https://github.com/Zarox28/ADBenQ"
+  url "https://github.com/Zarox28/ADBenQ/releases/download/v0.1.9/ADBenQ_macos.tar.gz"
+  sha256 "074682504602dfbe5e05ebffcdd3654c5049f4748318230b3f6071e141207d1d"
+  license "AGPL-3.0"
+
+  depends_on "scrcpy"
+  depends_on "python3"
+
+  def install
+    system "brew", "install", "--cask", "android-platform-tools" unless which("adb")
+
+    bin.install "adbenq"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Here is a list of the formulae available in this tap:
 
 - `Activate`: Activate MacOS is a playful macOS app that mimics the Windows activation message.
 - `SafeLock`: SafeLock is a simple macOS app that locks your screen and monitors for any unauthorized access.
+- `ADBenQ`: ADBenQ is a app that allows you to control your BenQ monitor from your Mac.
 - `...`: More formulae will be added soon!
 
 To install a formula from this tap, use:


### PR DESCRIPTION
## Pull Request Description

### Title
✨ feat: add ADBenQ formula for BenQ monitor control

### Description
This pull request introduces the ADBenQ formula, which allows users to control BenQ monitors directly from macOS. The addition of this formula enhances the user experience by providing a new tool for efficient monitor management.

### Changes Made
- Added the ADBenQ formula for seamless control of BenQ monitors.
- Updated the README to include ADBenQ in the list of available formulae, ensuring users are informed about this new feature.

This enhancement aims to streamline monitor management for Mac users, making it easier to adjust settings and improve overall usability.