### PR TITLE
✨ fix: update sha256 checksum for Adben formula

### DIFF
--- a/Formula/adbenq.rb
+++ b/Formula/adbenq.rb
@@ -2,7 +2,7 @@ class Adbenq < Formula
   desc "Control your BenQ TV like a boss 🖥️✨"
   homepage "https://github.com/Zarox28/ADBenQ"
   url "https://github.com/Zarox28/ADBenQ/releases/download/v0.1.9/ADBenQ_macos.tar.gz"
-  sha256 "074682504602dfbe5e05ebffcdd3654c5049f4748318230b3f6071e141207d1d"
+  sha256 "4b6ba86e20977f6c1c5bd718dd4b2851248f0c342b295dcdcb267aa46ab2795c"
   license "AGPL-3.0"
 
   depends_on "scrcpy"


### PR DESCRIPTION
Updates the256 checksum for thebenq formula to the 
latest release This ensures the integrity and authenticity of 
the downloaded package.